### PR TITLE
Add `Array#wrap` method into core_ext

### DIFF
--- a/lib/core_ext/array.rb
+++ b/lib/core_ext/array.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Array
+  def self.wrap(object)
+    if object.nil?
+      []
+    elsif object.respond_to?(:to_ary)
+      object.to_ary || [object]
+    else
+      [object]
+    end
+  end
+end

--- a/lib/core_ext/core_ext.rb
+++ b/lib/core_ext/core_ext.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
 require_relative 'blank'
 require_relative 'snake_case'
 require_relative 'hash'
+require_relative 'array'

--- a/lib/core_ext/hash.rb
+++ b/lib/core_ext/hash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Object
   def deep_symbolize_keys
     return self.reduce({}) do |memo, (k, v)|


### PR DESCRIPTION
Somehow GraphQL call this [Rails method](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/array/wrap.rb#L37) when we pass an argument inside the query. If we not define it, we will get errors something like `undefined method 'wrap' for Array`. 

Here is an example:

```ruby
# frozen_string_literal: true

module ProcuraEngine
  module Presenter
    class MeasurementUnitGraphql < GraphqlBase
      MeasurementUnitType = GraphQL::ObjectType.define do
        name 'Measurement Unit'

        field :id, !types.ID
        field :ident_name, !types.String
        field :name, !types.String
        field :symbol, types.String
        field :desc, types.String
        field :created_at, DateTimeType
        field :updated_at, DateTimeType
        field :updated_by_id, !types.Int
        field :created_by_id, !types.Int
      end

      QueryType = GraphQL::ObjectType.define do
        name 'Query'

        field :items do
          type types[MeasurementUnitType]
          argument :id, types.Int, 'Measurement Unit ID'
          resolve -> (obj, args, context) do
            if args.blank?
              context[:measurement_unit_repo].all
            else
              context[:measurement_unit_repo].query(args.to_h.deep_symbolize_keys)
            end
          end
        end
        field :resource, !types.String do
          resolve -> (_obj, _args, _context) { 'measurement_unit' }
        end
        field :total_server_items, !types.Int do
          resolve -> (_obj, _args, context) { context[:measurement_unit_repo].count }
        end
      end

      Schema = GraphQL::Schema.define do
        query QueryType
      end

      def execute(measurement_unit_repo, graphql_str = nil)
        graphql_str ||= %{
          query {
            resource
            total_server_items
            items(id: 1) {
              ident_name
              name
              symbol
              desc
              created_at
              created_by_id
            }
          }
        }
        Schema.execute(graphql_str, context: { measurement_unit_repo: measurement_unit_repo })
      end
    end
  end
end

```

I passed an `ID` for `items`. Here is related issue from GraphQL repository

- [#716](https://github.com/rmosolgo/graphql-ruby/pull/716)
- [!839](https://github.com/rmosolgo/graphql-ruby/issues/839)